### PR TITLE
Use spawn instead of exec

### DIFF
--- a/blamer.js
+++ b/blamer.js
@@ -17,7 +17,7 @@ const blamer = {
         this.editor = vscode.window.activeTextEditor;
         this.extensionPath = vscode.extensions.getExtension('beaugust.blamer-vs').extensionPath;
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
-        
+
         this.updateStatusBar('Blamer Started');
 
         subversion.init(this.editor)
@@ -33,9 +33,9 @@ const blamer = {
                         .catch(error => this.handleError(error));
                 })
             }).catch((error) => this.handleError(error));
-    },   
-        
-    destroy() { 
+    },
+
+    destroy() {
         subversion.destroy();
         decoration.destroy();
         this.editor = '';
@@ -55,10 +55,10 @@ const blamer = {
                 this.updateStatusBar(`Processing revision ${commit.revision}`);
                 this.images[unique] = {
                     image: this.randomImage(),
-                    revision: commit.revision,
-                    email: commit.email,
-                    date: commit.date,
-                    message: commit.message,  
+                    revision: commit.revision || '',
+                    email: commit.email || '',
+                    date: commit.date || '',
+                    message: commit.message || '',
                 }
             })
             .catch(error => this.handleError(error))
@@ -66,13 +66,13 @@ const blamer = {
 
         return Promise.all(promises);
     },
-    
+
     setLines(revisions) {
         Object.entries(revisions).forEach(([line, revision]) => {
             decoration.set(this.editor, line, this.images[revision]);
         });
     },
-    
+
     getFiles() {
         return new Promise((resolve) => {
             fs.readdir(`${blamer.extensionPath}/img`, (err, files) => {
@@ -85,7 +85,7 @@ const blamer = {
     randomImage() {
         const length = this.files.length;
         const index = Math.floor(Math.random() * length);
-        const image = this.files[index]; 
+        const image = this.files[index];
         this.files.splice(index, 1);
         return image;
     },

--- a/subversion.js
+++ b/subversion.js
@@ -12,7 +12,7 @@ const subversion = {
 
     init(editor) {
         this.destroy();
-        this.path = editor.document.fileName.replace(/\$/g,'\\$');
+        this.path = editor.document.fileName.replace(/\$/g, '\\$');
         this.name = path.basename(this.path);
 
         if (this.path === this.name) return vscode.window.showInformationMessage('Blamer: Cannot identify file');
@@ -28,7 +28,7 @@ const subversion = {
     blame() {
         return new Promise((resolve, reject) => {
             const script = `svn blame -x "-w --ignore-eol-style" "${this.path}"`;
-            child_process.exec(script, {maxBuffer: _MAX_BUFFER}, (error, stdout, stderr) => {
+            child_process.exec(script, { maxBuffer: _MAX_BUFFER }, (error, stdout, stderr) => {
                 if (error) { reject(stderr); }
                 const revisions = this.getRevisions(stdout);
                 resolve(revisions);
@@ -52,16 +52,24 @@ const subversion = {
         if (Object.keys(this.revisions).length === 0) return;
         return new Promise((resolve, reject) => {
             const script = `svn log -r${revision} "${this.path}" --xml`;
-            child_process.exec(script, {maxBuffer: _MAX_BUFFER}, (error, stdout, stderr) => {
+            child_process.exec(script, { maxBuffer: _MAX_BUFFER }, (error, stdout, stderr) => {
                 if (error) { reject(stderr); }
 
-                const revision = stdout.match(/revision="(.*)">/)[1];
-                const email = stdout.match(/<author>([^<]*)<\/author>/)[1];
-                const message = stdout.match(/<msg>([^<]*)<\/msg>/)[1];
-                let date = stdout.match(/<date>([^<]*)<\/date>/)[1];
+                const commit = {};
+                if (commit.revision = stdout.match(/revision="(.*)">/)) {
+                    commit.revision = commit.revision[1];
+                }
+                if (commit.email = stdout.match(/<author>([^<]*)<\/author>/)) {
+                    commit.email = commit.email[1];
+                }
+                if (commit.message = stdout.match(/<msg>([^<]*)<\/msg>/)) {
+                    commit.message = commit.message[1];
+                }
+                if (commit.date = stdout.match(/<date>([^<]*)<\/date>/)) {
+                    commit.date = formatDate(commit.date[1]);
+                }
 
-                date = formatDate(date);
-                resolve({ email, revision, date, message });        
+                resolve(commit);
             });
         });
     },


### PR DESCRIPTION
This PR uses child_process.spawn instead of child_process.exec with a buffer size limit so that this extension can process files larger than 500 kB.

It is based off of #54, so it has the changes from that branch in it already.