### PR TITLE
Resolve NaN error on revision numbers longer than 5 digits

### DIFF
--- a/subversion.js
+++ b/subversion.js
@@ -45,9 +45,8 @@ const subversion = {
         const lines = data.split(/\n/);
 
         lines.forEach((line, index) => {
-            if (line.substring(5, 6) === '-') return;
             const revision = line.split(' ').filter(s => s)[0];
-            if (revision) this.revisions[index] = parseInt(revision);
+            if (revision && revision != '-') this.revisions[index] = parseInt(revision);
         });
 
         return this.revisions;


### PR DESCRIPTION
I was getting an error when I ran blame on files with local edits, "svn E205000: Syntax error in revision argument 'NaN'". It looks like if the revision number was  longer than 5 characters, the check for '-' would fail, and we would try to parse '-' as the revision. 