### PR TITLE
chore: disable draft releases in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,8 @@
             "release-type": "node",
             "include-component-in-tag": false,
             "include-v-in-tag": true,
-            "draft": true,
-            "draft-pull-request": true,
+            "draft": false,
+            "draft-pull-request": false,
             "changelog-sections": [
                 {
                     "type": "feat",


### PR DESCRIPTION
Sets draft and draft-pull-request to false so that release-please creates normal PRs and releases.