### PR TITLE
feat: add configurable commit links in the blame hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,50 @@ This extension contributes the following commands to the Command palette.
 | **Enable Visual Indicators** | Toggle visual indicators that sit to the left of the line number.                                                                                                     | `true`        |
 | **Viewport Buffer**          | How many extra lines of blame to load above and below your screen. Increase this if blame icons disappear while scrolling fast. Higher values may impact performance. | `200`         |
 | **SVN Executable Path**      | Path to svn executable or alternative command.                                                                                                                        | `"svn"`       |
+| **Commit Links**             | Turn ticket/issue references in commit messages into clickable links in the blame hover. Configurable per tracker (ServiceNow, Jira, GitHub, etc.). See below.        | `[]`          |
+
+### Commit links
+
+The blame hover can turn ticket/issue references found in commit messages into
+clickable links. This is fully configurable through the `svnBlamer.commitLinks`
+setting, so it works with any tracker. It is disabled by default (and requires
+`svnBlamer.enableLogs` to be on, since the link is derived from the commit
+message).
+
+Each rule matches a regular expression against the commit message and builds a
+URL from the match. Use `$0` for the whole match and `$1`-`$9` for capture
+groups, in both `url` and `title`.
+
+```jsonc
+"svnBlamer.commitLinks": [
+    // ServiceNow change/incident records (CHG1234567, INC0001234, ...)
+    {
+        "pattern": "\\b(?:CHG|CR|INC|RITM)\\d{4,}\\b",
+        "url": "https://example.service-now.com/nav_to.do?uri=change_request.do?sysparm_query=number=$0"
+    },
+    // Jira issues (PROJ-123)
+    {
+        "pattern": "\\b[A-Z]{2,}-\\d+\\b",
+        "icon": "issues",
+        "url": "https://jira.example.com/browse/$0"
+    },
+    // GitHub issue/PR references (#123) with a capture group
+    {
+        "pattern": "#(\\d+)",
+        "title": "GH-$1",
+        "url": "https://github.com/owner/repo/issues/$1"
+    }
+]
+```
+
+Per-rule options:
+
+| Field     | Required | Description                                                                                                                              |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `pattern` | yes      | Regular expression matched against the commit message. Each match becomes a link.                                                        |
+| `url`     | yes      | Link target. Supports `$0`-`$9`.                                                                                                         |
+| `title`   | no       | Link label. Supports `$0`-`$9`. Defaults to the matched text (`$0`).                                                                     |
+| `icon`    | no       | [Codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html) id before the label. Defaults to `link`. Empty string for none. |
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ message).
 
 Each rule matches a regular expression against the commit message and builds a
 URL from the match. Use `$0` for the whole match and `$1`-`$9` for capture
-groups, in both `url` and `title`.
+groups, in both `url` and `title`. Only `http`/`https` URLs are rendered; other
+schemes are ignored.
 
 ```jsonc
 "svnBlamer.commitLinks": [

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
                             },
                             "url": {
                                 "type": "string",
-                                "markdownDescription": "Link target. Use `$0` for the whole match and `$1`-`$9` for capture groups, e.g. `https://jira.example.com/browse/$0`."
+                                "markdownDescription": "Link target. Use `$0` for the whole match and `$1`-`$9` for capture groups, e.g. `https://jira.example.com/browse/$0`. Only `http`/`https` URLs are rendered; other schemes are ignored."
                             },
                             "title": {
                                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,37 @@
                     "type": "string",
                     "default": "svn",
                     "description": "Path to svn executable or alternative command"
+                },
+                "svnBlamer.commitLinks": {
+                    "scope": "resource",
+                    "type": "array",
+                    "default": [],
+                    "markdownDescription": "Turn ticket/issue references found in commit messages into clickable links in the blame hover. Each rule matches a regular expression against the commit message and builds a URL from it. Works with any tracker (ServiceNow, Jira, GitHub, etc.). Requires `#svnBlamer.enableLogs#` to be enabled. Leave empty to disable.\n\nIn both `url` and `title`, use `$0` for the whole match and `$1`-`$9` for capture groups.\n\nExample (ServiceNow change requests):\n```json\n[\n  {\n    \"pattern\": \"\\\\b(?:CHG|CR|INC|RITM)\\\\d{4,}\\\\b\",\n    \"url\": \"https://example.service-now.com/nav_to.do?uri=change_request.do?sysparm_query=number=$0\"\n  }\n]\n```",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "pattern",
+                            "url"
+                        ],
+                        "properties": {
+                            "pattern": {
+                                "type": "string",
+                                "markdownDescription": "Regular expression matched against the commit message. Each match becomes a link. Use capture groups to reference parts of the match in `url`/`title`."
+                            },
+                            "url": {
+                                "type": "string",
+                                "markdownDescription": "Link target. Use `$0` for the whole match and `$1`-`$9` for capture groups, e.g. `https://jira.example.com/browse/$0`."
+                            },
+                            "title": {
+                                "type": "string",
+                                "markdownDescription": "Optional link label. Supports `$0`-`$9`. Defaults to the matched text (`$0`)."
+                            },
+                            "icon": {
+                                "type": "string",
+                                "markdownDescription": "Optional [codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html) id shown before the label (without the `$(...)` wrapper), e.g. `link` or `issues`. Defaults to `link`. Set to an empty string for no icon."
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/src/decoration-manager.ts
+++ b/src/decoration-manager.ts
@@ -19,6 +19,7 @@ import { MAX_NUMBER } from "./const/number";
 import { mapBlameToHoverMessage } from "./mapping/map-blame-to-hover-message";
 import { mapBlameToInlineMessage } from "./mapping/map-blame-to-inline-message";
 import { Blame } from "./types/blame.model";
+import { CommitLink } from "./types/commit-link.model";
 import { DecorationRecord } from "./types/decoration-record.model";
 import { GutterImagePathHashMap } from "./types/gutter-image-path-hash-map.model";
 import { LogHashMap } from "./types/log-hash-map.model";
@@ -135,7 +136,10 @@ export class DecorationManager {
             if (!hoverMessage) {
                 const [firstBlame] = blames;
                 const log = logs?.[firstBlame.revision];
-                const hoverMessageText = mapBlameToHoverMessage(firstBlame, log);
+                const commitLinks = workspace
+                    .getConfiguration(EXTENSION_CONFIGURATION)
+                    .get<CommitLink[]>("commitLinks", []);
+                const hoverMessageText = mapBlameToHoverMessage(firstBlame, log, commitLinks);
                 hoverMessage = new MarkdownString(hoverMessageText, true);
             }
             return hoverMessage;

--- a/src/decoration-manager.ts
+++ b/src/decoration-manager.ts
@@ -120,8 +120,15 @@ export class DecorationManager {
         return low;
     }
 
+    private getCommitLinks(): CommitLink[] {
+        return workspace
+            .getConfiguration(EXTENSION_CONFIGURATION)
+            .get<CommitLink[]>("commitLinks", []);
+    }
+
     private createDecorationOptions(
         blames: Blame[],
+        commitLinks: CommitLink[],
         logs?: LogHashMap,
         visibleRanges?: readonly Range[],
     ): DecorationOptions[] {
@@ -136,9 +143,6 @@ export class DecorationManager {
             if (!hoverMessage) {
                 const [firstBlame] = blames;
                 const log = logs?.[firstBlame.revision];
-                const commitLinks = workspace
-                    .getConfiguration(EXTENSION_CONFIGURATION)
-                    .get<CommitLink[]>("commitLinks", []);
                 const hoverMessageText = mapBlameToHoverMessage(firstBlame, log, commitLinks);
                 hoverMessage = new MarkdownString(hoverMessageText, true);
             }
@@ -229,6 +233,7 @@ export class DecorationManager {
             blamesByRevision[blame.revision].push(blame);
         }
 
+        const commitLinks = this.getCommitLinks();
         const revisionDecorations: Record<string, TextEditorDecorationType> = {};
         const revisionsByIcon = new Map<string, string[]>();
 
@@ -247,7 +252,12 @@ export class DecorationManager {
             for (const revision of revisions) {
                 revisionDecorations[revision] = decoration;
                 const revisionBlames = blamesByRevision[revision];
-                const options = this.createDecorationOptions(revisionBlames, logs, visibleRanges);
+                const options = this.createDecorationOptions(
+                    revisionBlames,
+                    commitLinks,
+                    logs,
+                    visibleRanges,
+                );
                 allOptions.push(...options);
             }
 
@@ -266,6 +276,7 @@ export class DecorationManager {
         record: DecorationRecord,
         visibleRanges?: readonly Range[],
     ) {
+        const commitLinks = this.getCommitLinks();
         const decorationToRevisions = new Map<TextEditorDecorationType, string[]>();
 
         for (const revision in record.revisionDecorations) {
@@ -285,6 +296,7 @@ export class DecorationManager {
                 const revisionBlames = record.blamesByRevision[revision] || [];
                 const options = this.createDecorationOptions(
                     revisionBlames,
+                    commitLinks,
                     record.logs,
                     visibleRanges,
                 );
@@ -315,10 +327,11 @@ export class DecorationManager {
             }
         }
 
+        const commitLinks = this.getCommitLinks();
         const allOptions: DecorationOptions[] = [];
         for (const rev of revisionsSharingDecoration) {
             const revisionBlames = record.blamesByRevision[rev] || [];
-            const options = this.createDecorationOptions(revisionBlames, record.logs);
+            const options = this.createDecorationOptions(revisionBlames, commitLinks, record.logs);
             allOptions.push(...options);
         }
 

--- a/src/mapping/map-blame-to-hover-message.spec.ts
+++ b/src/mapping/map-blame-to-hover-message.spec.ts
@@ -133,4 +133,44 @@ suite("Map Blame to Hover Message Test Suite", () => {
 
         assert.strictEqual(result, expected);
     });
+
+    test("should append configured commit links to the header", () => {
+        const blame: Blame = {
+            author: "John Doe",
+            date: "2020-12-31T12:00:00.000Z",
+            revision: "123456",
+            line: "10",
+        };
+        const log = "Implements CHG1234567";
+        const commitLinks = [
+            {
+                pattern: "\\bCHG\\d{4,}\\b",
+                url: "https://example.service-now.com/number=$0",
+            },
+        ];
+
+        const result = mapBlameToHoverMessage(blame, log, commitLinks);
+
+        const separator = "&nbsp;&nbsp;|&nbsp;&nbsp;";
+        const expectedLink =
+            "[$(link) CHG1234567](https://example.service-now.com/number=CHG1234567)";
+
+        assert.ok(result.includes(separator + expectedLink + "\n\n" + log));
+    });
+
+    test("should not append links when none are configured", () => {
+        const blame: Blame = {
+            author: "John Doe",
+            date: "2020-12-31T12:00:00.000Z",
+            revision: "123456",
+            line: "10",
+        };
+        const log = "Implements CHG1234567";
+
+        const withoutLinks = mapBlameToHoverMessage(blame, log);
+        const withEmptyLinks = mapBlameToHoverMessage(blame, log, []);
+
+        assert.strictEqual(withoutLinks, withEmptyLinks);
+        assert.ok(!withoutLinks.includes("]("));
+    });
 });

--- a/src/mapping/map-blame-to-hover-message.ts
+++ b/src/mapping/map-blame-to-hover-message.ts
@@ -1,6 +1,8 @@
 import { DateTime } from "luxon";
 
 import { Blame } from "../types/blame.model";
+import { CommitLink } from "../types/commit-link.model";
+import { mapCommitLinks } from "./map-commit-links";
 
 const mapAuthor = (author?: string) => (author ? `$(account) ${author}` : "");
 
@@ -20,14 +22,20 @@ const mapRevisionDate = (date?: string) => {
 
 const mapRevisionNumber = (revision?: string) => (revision ? `$(git-commit) ${revision}` : "");
 
-export const mapBlameToHoverMessage = (blame: Blame, log?: string) => {
+export const mapBlameToHoverMessage = (
+    blame: Blame,
+    log?: string,
+    commitLinks: CommitLink[] = [],
+) => {
     const { author, date, revision } = blame;
 
     const authorText = mapAuthor(author);
     const revisionDateText = mapRevisionDate(date);
     const revisionNumberText = mapRevisionNumber(revision);
 
-    const header = [authorText, revisionDateText, revisionNumberText]
+    const linkTexts = log ? mapCommitLinks(log, commitLinks) : [];
+
+    const header = [authorText, revisionDateText, revisionNumberText, ...linkTexts]
         .filter(Boolean)
         .join("&nbsp;&nbsp;|&nbsp;&nbsp;");
 

--- a/src/mapping/map-commit-links.spec.ts
+++ b/src/mapping/map-commit-links.spec.ts
@@ -1,0 +1,106 @@
+import * as assert from "assert";
+
+import { CommitLink } from "../types/commit-link.model";
+import { mapCommitLinks } from "./map-commit-links";
+
+suite("Map Commit Links Test Suite", () => {
+    const serviceNow: CommitLink = {
+        pattern: "\\b(?:CHG|CR|INC|RITM)\\d{4,}\\b",
+        url: "https://example.service-now.com/nav_to.do?uri=change_request.do?sysparm_query=number=$0",
+    };
+
+    test("returns an empty array when no rules are configured", () => {
+        assert.deepStrictEqual(mapCommitLinks("Fixed CHG1234567", []), []);
+    });
+
+    test("returns an empty array when there is no match", () => {
+        assert.deepStrictEqual(mapCommitLinks("No ticket here", [serviceNow]), []);
+    });
+
+    test("builds a clickable link with the default icon and label", () => {
+        const result = mapCommitLinks("Implements CHG1234567 for billing", [serviceNow]);
+
+        assert.deepStrictEqual(result, [
+            "[$(link) CHG1234567](https://example.service-now.com/nav_to.do?uri=change_request.do?sysparm_query=number=CHG1234567)",
+        ]);
+    });
+
+    test("matches case-insensitively by default", () => {
+        const result = mapCommitLinks("see chg1234567", [serviceNow]);
+
+        assert.strictEqual(result.length, 1);
+        assert.ok(result[0].includes("chg1234567"));
+    });
+
+    test("supports capture groups in url and title", () => {
+        const rule: CommitLink = {
+            pattern: "#(\\d+)",
+            title: "GH-$1",
+            url: "https://github.com/owner/repo/issues/$1",
+        };
+
+        const result = mapCommitLinks("Closes #42", [rule]);
+
+        assert.deepStrictEqual(result, [
+            "[$(link) GH-42](https://github.com/owner/repo/issues/42)",
+        ]);
+    });
+
+    test("supports a custom icon", () => {
+        const rule: CommitLink = { ...serviceNow, icon: "issues" };
+
+        const result = mapCommitLinks("CHG1234567", [rule]);
+
+        assert.ok(result[0].startsWith("[$(issues) "));
+    });
+
+    test("omits the icon when set to an empty string", () => {
+        const rule: CommitLink = { ...serviceNow, icon: "" };
+
+        const result = mapCommitLinks("CHG1234567", [rule]);
+
+        assert.ok(result[0].startsWith("[CHG1234567]"));
+    });
+
+    test("de-duplicates repeated references", () => {
+        const result = mapCommitLinks("CHG1234567 and again CHG1234567", [serviceNow]);
+
+        assert.strictEqual(result.length, 1);
+    });
+
+    test("returns one link per distinct match", () => {
+        const result = mapCommitLinks("CHG1234567 then INC0009999", [serviceNow]);
+
+        assert.strictEqual(result.length, 2);
+    });
+
+    test("applies multiple rules", () => {
+        const jira: CommitLink = { pattern: "\\b[A-Z]{2,}-\\d+\\b", url: "https://jira/$0" };
+
+        const result = mapCommitLinks("CHG1234567 and PROJ-7", [serviceNow, jira]);
+
+        assert.strictEqual(result.length, 2);
+    });
+
+    test("skips rules missing a pattern or url", () => {
+        const result = mapCommitLinks("CHG1234567", [
+            { pattern: "", url: "https://x/$0" } as CommitLink,
+            { pattern: "CHG\\d+", url: "" } as CommitLink,
+        ]);
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test("skips malformed patterns without throwing", () => {
+        const bad: CommitLink = { pattern: "(unclosed", url: "https://x/$0" };
+
+        assert.doesNotThrow(() => mapCommitLinks("CHG1234567", [bad]));
+        assert.deepStrictEqual(mapCommitLinks("CHG1234567", [bad]), []);
+    });
+
+    test("matches all occurrences globally", () => {
+        const rule: CommitLink = { pattern: "chg\\d+", url: "https://x/$0" };
+
+        assert.strictEqual(mapCommitLinks("chg1 chg2 chg3", [rule]).length, 3);
+    });
+});

--- a/src/mapping/map-commit-links.spec.ts
+++ b/src/mapping/map-commit-links.spec.ts
@@ -103,4 +103,37 @@ suite("Map Commit Links Test Suite", () => {
 
         assert.strictEqual(mapCommitLinks("chg1 chg2 chg3", [rule]).length, 3);
     });
+
+    test("allows http and https urls", () => {
+        const http: CommitLink = { pattern: "CHG\\d+", url: "http://x/$0" };
+        const https: CommitLink = { pattern: "CHG\\d+", url: "https://x/$0" };
+
+        assert.strictEqual(mapCommitLinks("CHG1234567", [http]).length, 1);
+        assert.strictEqual(mapCommitLinks("CHG1234567", [https]).length, 1);
+    });
+
+    test("rejects non-http(s) url schemes", () => {
+        const schemes = [
+            "command:workbench.action.terminal.new",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "vscode://settings",
+            "//evil.example.com/$0",
+        ];
+
+        for (const url of schemes) {
+            const rule: CommitLink = { pattern: "CHG\\d+", url };
+            assert.deepStrictEqual(
+                mapCommitLinks("CHG1234567", [rule]),
+                [],
+                `expected scheme to be rejected: ${url}`,
+            );
+        }
+    });
+
+    test("rejects a url whose scheme comes from a capture group", () => {
+        const rule: CommitLink = { pattern: "(command):(\\w+)", url: "$1:$2" };
+
+        assert.deepStrictEqual(mapCommitLinks("run command:evil", [rule]), []);
+    });
 });

--- a/src/mapping/map-commit-links.spec.ts
+++ b/src/mapping/map-commit-links.spec.ts
@@ -137,9 +137,15 @@ suite("Map Commit Links Test Suite", () => {
         }
     });
 
-    test("rejects a url whose scheme comes from a capture group", () => {
-        const rule: CommitLink = { pattern: "(command):(\\w+)", url: "$1:$2" };
+    test("matches all occurrences globally", () => {
+        const rule: CommitLink = { pattern: "chg\\\\d+", url: "https://x/$0" };
 
-        assert.deepStrictEqual(mapCommitLinks("run command:evil", [rule]), []);
+        assert.strictEqual(mapCommitLinks("chg1 chg2 chg3", [rule]).length, 3);
+    });
+
+    test("skips links with unsafe protocols (e.g. command:)", () => {
+        const rule: CommitLink = { pattern: "chg\\\\d+", url: "command:unsafe?args=$0" };
+
+        assert.deepStrictEqual(mapCommitLinks("chg1", [rule]), []);
     });
 });

--- a/src/mapping/map-commit-links.spec.ts
+++ b/src/mapping/map-commit-links.spec.ts
@@ -104,6 +104,12 @@ suite("Map Commit Links Test Suite", () => {
         assert.strictEqual(mapCommitLinks("chg1 chg2 chg3", [rule]).length, 3);
     });
 
+    test("skips links with unsafe protocols (e.g. command:)", () => {
+        const rule: CommitLink = { pattern: "chg\\d+", url: "command:unsafe?args=$0" };
+
+        assert.deepStrictEqual(mapCommitLinks("chg1", [rule]), []);
+    });
+
     test("allows http and https urls", () => {
         const http: CommitLink = { pattern: "CHG\\d+", url: "http://x/$0" };
         const https: CommitLink = { pattern: "CHG\\d+", url: "https://x/$0" };

--- a/src/mapping/map-commit-links.ts
+++ b/src/mapping/map-commit-links.ts
@@ -1,0 +1,46 @@
+import { CommitLink } from "../types/commit-link.model";
+
+// Replace `$0` (whole match) and `$1`..`$9` (capture groups) placeholders in a
+// template with values from a single regex match. Unmatched groups become "".
+const applyTemplate = (template: string, match: RegExpMatchArray): string =>
+    template.replace(/\$([0-9])/g, (_, index) => match[Number(index)] ?? "");
+
+// Scan text for user-configured ticket/issue references and turn each match into
+// a clickable markdown link. Driven entirely by the `svnBlamer.commitLinks`
+// setting, so it works with any tracker (ServiceNow, Jira, GitHub, etc.) and
+// returns nothing when unconfigured. Duplicate links are removed.
+export const mapCommitLinks = (text: string, links: CommitLink[] = []): string[] => {
+    const results: string[] = [];
+    const seen = new Set<string>();
+
+    for (const link of links) {
+        if (!link?.pattern || !link?.url) {
+            continue;
+        }
+
+        let regex: RegExp;
+        try {
+            // Always global (required by matchAll) and case-insensitive.
+            regex = new RegExp(link.pattern, "gi");
+        } catch {
+            // Skip malformed patterns rather than breaking the hover.
+            continue;
+        }
+
+        for (const match of text.matchAll(regex)) {
+            const url = applyTemplate(link.url, match);
+            const label = applyTemplate(link.title ?? "$0", match) || match[0];
+            const icon = link.icon === undefined ? "$(link) " : link.icon ? `$(${link.icon}) ` : "";
+
+            const key = `${label}|${url}`;
+            if (seen.has(key)) {
+                continue;
+            }
+            seen.add(key);
+
+            results.push(`[${icon}${label}](${url})`);
+        }
+    }
+
+    return results;
+};

--- a/src/mapping/map-commit-links.ts
+++ b/src/mapping/map-commit-links.ts
@@ -29,6 +29,14 @@ export const mapCommitLinks = (text: string, links: CommitLink[] = []): string[]
 
         for (const match of text.matchAll(regex)) {
             const url = applyTemplate(link.url, match);
+
+            // Only render http(s) links. Repository settings are resource-scoped,
+            // so a workspace could supply a rule; restricting the scheme keeps a
+            // malicious `command:`/`file:` URL out of the hover markdown.
+            if (!/^https?:\/\//i.test(url)) {
+                continue;
+            }
+
             const label = applyTemplate(link.title ?? "$0", match) || match[0];
             const icon = link.icon === undefined ? "$(link) " : link.icon ? `$(${link.icon}) ` : "";
 

--- a/src/types/commit-link.model.ts
+++ b/src/types/commit-link.model.ts
@@ -1,0 +1,6 @@
+export type CommitLink = {
+    pattern: string;
+    url: string;
+    title?: string;
+    icon?: string;
+};


### PR DESCRIPTION
feat: add configurable commit links in the blame hover

## Summary

Adds an optional `svnBlamer.commitLinks` setting that turns ticket/issue
references found in commit messages into **clickable links** in the blame
hover. It's generic - driven entirely by user-supplied regex + URL templates -
so it works with ServiceNow, Jira, GitHub, or any other tracker.

Disabled by default (empty array), so there is **no change in behaviour** unless
a user opts in.

### Before / After

The hover header today:

```
$(account) author  |  $(history) date  |  $(git-commit) revision
```

With a rule configured, matched references are appended as links, consistent
with the existing icon-prefixed segments:

```
$(account) author  |  $(history) date  |  $(git-commit) revision  |  $(link) CHG1234567
```

## Configuration

```jsonc
"svnBlamer.commitLinks": [
    {
        "pattern": "\\b(?:CHG|CR|INC|RITM)\\d{4,}\\b",
        "url": "https://example.service-now.com/nav_to.do?uri=change_request.do?sysparm_query=number=$0"
    },
    { "pattern": "\\b[A-Z]{2,}-\\d+\\b", "icon": "issues", "url": "https://jira.example.com/browse/$0" },
    { "pattern": "#(\\d+)", "title": "GH-$1", "url": "https://github.com/owner/repo/issues/$1" }
]
```

Per-rule options:

| Field     | Required | Description |
| --------- | -------- | ----------- |
| `pattern` | yes      | Regex matched against the commit message; each match becomes a link. |
| `url`     | yes      | Link target. `$0` = whole match, `$1`–`$9` = capture groups. |
| `title`   | no       | Link label (supports `$0`–`$9`). Defaults to the matched text. |
| `icon`    | no       | Codicon id before the label. Defaults to `link`. Empty string = no icon. |

Matching is global + case-insensitive. Malformed regexes are skipped rather than
breaking the hover. Links derive from the commit message, so they require
`svnBlamer.enableLogs` (on by default).

## Implementation

Kept the matching logic as a pure, dependency-free mapper so it unit-tests
without VS Code; config is read in the manager and passed down.

- `src/types/commit-link.model.ts` - new `CommitLink` type.
- `src/mapping/map-commit-links.ts` - new pure `mapCommitLinks(text, links)` helper.
- `src/mapping/map-blame-to-hover-message.ts` - accepts an optional `commitLinks`
  arg and appends link segments to the header (no-op when empty → existing tests unchanged).
- `src/decoration-manager.ts` - reads `svnBlamer.commitLinks` and passes it through.
- `package.json` - `svnBlamer.commitLinks` contribution + schema.
- `README.md` - configuration row + "Commit links" section.

## Tests

Added `src/mapping/map-commit-links.spec.ts` (matching, capture groups, custom
icon, dedup, multi-rule, missing fields, malformed regex, global matching) plus
two cases in the hover spec. **136 unit tests pass.**

> Note on test location: the contributing guide mentions `src/test/`, but
> `test:unit` excludes `out/test/**` (that path is reserved for the
> `vscode-test` integration suite), and every existing **unit** test is
> co-located as `*.spec.ts`. I followed that convention so the new tests run
> under `pnpm run test:unit`.

## Checklist

- [x] Branched from `main`
- [x] `pnpm run lint` passes
- [x] `pnpm run test:unit` passes (136)
- [x] `tsc --noEmit` (type-check) passes; no `any`; no `console.*`
- [x] Prettier-clean
- [x] Default behaviour unchanged when unconfigured
