### PR TITLE
feat: add customizable indicator gradients

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ When run, this extension will place an icon next to each line of your file. Each
 
 **Note**: This extension leverages your machine's SVN installation, so you need to install [SVN](https://subversion.apache.org/) first.
 
+SVN Blamer requires Visual Studio Code 1.66 or later.
+
 ### Windows users
 
 If you use TortoiseSVN, make sure the option Command Line Tools is checked during installation, and C:\Program Files\TortoiseSVN\bin is available in PATH.
@@ -82,16 +84,19 @@ This extension contributes the following commands to the Command palette.
 
 ## Configuration
 
-| Setting                      | Description                                                                                                                                                           | Default value |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| **Auto Blame**               | Automatically blames files as you open them.                                                                                                                          | `false`       |
-| **Enable Logs**              | Fetches and displays revision log data in the popup.                                                                                                                  | `true`        |
-| **Enable Visual Indicators** | Toggle visual indicators that sit to the left of the line number.                                                                                                     | `true`        |
-| **Indicator colour scheme**  | `random` preserves the existing mixed colours. Other schemes map oldest to newest revisions: red to green, or white fading to blue, teal, violet, or vermilion.       | `random`      |
-| **Viewport Buffer**          | How many extra lines of blame to load above and below your screen. Increase this if blame icons disappear while scrolling fast. Higher values may impact performance. | `200`         |
-| **SVN Executable Path**      | Path to svn executable or alternative command.                                                                                                                        | `"svn"`       |
+| Setting                             | Description                                                                                                                                                                                                                          | Default value |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| **Auto Blame**                      | Automatically blames files as you open them.                                                                                                                                                                                         | `false`       |
+| **Enable Logs**                     | Fetches and displays revision log data in the popup.                                                                                                                                                                                 | `true`        |
+| **Enable Visual Indicators**        | Toggle visual indicators that sit to the left of the line number.                                                                                                                                                                    | `true`        |
+| **Indicator colour scheme**         | `random` preserves the existing mixed colours. Red → Green maps oldest to newest. Blue, Teal, Violet, and Vermilion use white-to-strong gradients with a thin outline on light themes. Custom gradient uses the exact colours below. | `random`      |
+| **Oldest commit colour**            | Used only by Custom gradient. Enter an opaque `#RRGGBB` colour. It does not adapt to the active theme, so choose enough contrast.                                                                                                    | `#6b7280`     |
+| **Newest commit colour**            | Used only by Custom gradient. Enter an opaque `#RRGGBB` colour. It does not adapt to the active theme, so choose enough contrast.                                                                                                    | `#1f5f9f`     |
+| **Custom indicator outline colour** | Used only by Custom gradient. Optionally enter an opaque `#RRGGBB` colour to outline each indicator. Leave blank for no outline.                                                                                                     | `""`          |
+| **Viewport Buffer**                 | How many extra lines of blame to load above and below your screen. Increase this if blame icons disappear while scrolling fast. Higher values may impact performance.                                                                | `200`         |
+| **SVN Executable Path**             | Path to svn executable or alternative command.                                                                                                                                                                                       | `"svn"`       |
 
-All chronological schemes have 500 positions. Files with more than 500 revisions reuse the nearest position.
+All chronological schemes have 500 positions. Files with more than 500 revisions reuse the nearest position. The Blue, Teal, Violet, and Vermilion schemes use the same white-to-strong gradient in every theme. Light and High Contrast Light add a thin outline so older commits remain visible. Custom gradient accepts identical colours when you want a single-colour indicator.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "homepage": "https://github.com/BeauAgst/blamer-vs",
     "icon": "dist/img/marketplace/icon.png",
     "engines": {
-        "vscode": "^1.63.0",
+        "vscode": "^1.66.0",
         "node": "^24.0.0",
         "pnpm": "^10.0.0"
     },
@@ -100,7 +100,8 @@
                         "blue",
                         "teal",
                         "violet",
-                        "vermilion"
+                        "vermilion",
+                        "custom"
                     ],
                     "enumItemLabels": [
                         "Random",
@@ -108,20 +109,51 @@
                         "Blue",
                         "Teal",
                         "Violet",
-                        "Vermilion"
+                        "Vermilion",
+                        "Custom gradient"
                     ],
                     "enumDescriptions": [
                         "Assign stable, well-separated colours to revisions in each file.",
-                        "Older commits are redder and newer commits are greener. Files with more than 500 distinct revisions reuse the nearest colour.",
-                        "Older commits fade towards white and newer commits are bluer. Files with more than 500 distinct revisions reuse the nearest colour.",
-                        "Older commits fade towards white and newer commits are more teal. Files with more than 500 distinct revisions reuse the nearest colour.",
-                        "Older commits fade towards white and newer commits are more violet. Files with more than 500 distinct revisions reuse the nearest colour.",
-                        "Older commits fade towards white and newer commits are more vermilion. Files with more than 500 distinct revisions reuse the nearest colour."
+                        "Oldest commits are redder and newest commits are greener. Files with more than 500 distinct revisions reuse the nearest colour.",
+                        "Oldest commits are white and newest commits are bluer. A thin outline keeps older commits visible on light themes. Files with more than 500 distinct revisions reuse the nearest colour.",
+                        "Oldest commits are white and newest commits are more teal. A thin outline keeps older commits visible on light themes. Files with more than 500 distinct revisions reuse the nearest colour.",
+                        "Oldest commits are white and newest commits are more violet. A thin outline keeps older commits visible on light themes. Files with more than 500 distinct revisions reuse the nearest colour.",
+                        "Oldest commits are white and newest commits are more vermilion. A thin outline keeps older commits visible on light themes. Files with more than 500 distinct revisions reuse the nearest colour.",
+                        "Oldest and newest commits use the exact custom colours below. They do not adapt to the active theme. Files with more than 500 distinct revisions reuse the nearest colour."
                     ]
+                },
+                "svnBlamer.indicatorCustomOldestColor": {
+                    "scope": "resource",
+                    "order": 5,
+                    "title": "Oldest commit colour",
+                    "default": "#6b7280",
+                    "description": "Used only with Custom gradient. Enter an opaque #RRGGBB colour. This exact value does not adapt to the active theme, so use enough contrast.",
+                    "type": "string",
+                    "format": "color-hex",
+                    "pattern": "^#[0-9a-fA-F]{6}$"
+                },
+                "svnBlamer.indicatorCustomNewestColor": {
+                    "scope": "resource",
+                    "order": 6,
+                    "title": "Newest commit colour",
+                    "default": "#1f5f9f",
+                    "description": "Used only with Custom gradient. Enter an opaque #RRGGBB colour. This exact value does not adapt to the active theme, so use enough contrast.",
+                    "type": "string",
+                    "format": "color-hex",
+                    "pattern": "^#[0-9a-fA-F]{6}$"
+                },
+                "svnBlamer.indicatorCustomOutlineColor": {
+                    "scope": "resource",
+                    "order": 7,
+                    "title": "Custom indicator outline colour",
+                    "default": "",
+                    "description": "Used only with Custom gradient. Optionally enter an opaque #RRGGBB colour to outline each indicator. Leave blank for no outline.",
+                    "type": "string",
+                    "pattern": "^(|#[0-9a-fA-F]{6})$"
                 },
                 "svnBlamer.viewportBuffer": {
                     "scope": "resource",
-                    "order": 5,
+                    "order": 8,
                     "default": 200,
                     "description": "How many extra lines of blame to load above and below your screen. Increase this if blame icons disappear while scrolling fast. Note: Higher values may impact initial load performance.",
                     "type": "integer",
@@ -130,7 +162,7 @@
                 },
                 "svnBlamer.svnExecutablePath": {
                     "scope": "machine",
-                    "order": 6,
+                    "order": 9,
                     "type": "string",
                     "default": "svn",
                     "description": "Path to svn executable or alternative command"
@@ -184,7 +216,7 @@
         "@types/node": "26.x",
         "@types/sinon": "^21.0.0",
         "@types/sinonjs__fake-timers": "^15.0.1",
-        "@types/vscode": "^1.63.0",
+        "@types/vscode": "^1.66.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.65.0",
         "@vscode/test-cli": "^0.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         specifier: ^15.0.1
         version: 15.0.1
       '@types/vscode':
-        specifier: ^1.63.0
+        specifier: ^1.66.0
         version: 1.109.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.58.0

--- a/src/blamer.spec.ts
+++ b/src/blamer.spec.ts
@@ -46,6 +46,7 @@ suite("Blamer", () => {
             createGutterIconHashMap: sandbox.stub(),
             createAndSetDecorationsForBlame: sandbox.stub(),
             reApplyDecorations: sandbox.stub(),
+            usesThemeAwareIndicatorScheme: sandbox.stub().returns(false),
             updateRevisionHoverMessages: sandbox.stub(),
             setActiveLineDecoration: sandbox.stub(),
         } as unknown as sinon.SinonStubbedInstance<DecorationManager>;
@@ -452,6 +453,56 @@ suite("Blamer", () => {
                 ),
             );
         });
+
+        test("refreshes a theme-aware background tab after a theme change", async () => {
+            const fileName = "/test/theme-background.ts";
+            const textEditor = {
+                document: {
+                    fileName,
+                    uri: { fsPath: fileName, scheme: "vscode-remote" },
+                },
+                visibleRanges: [{ start: { line: 0 }, end: { line: 1 } }],
+            } as unknown as TextEditor;
+            const record: DecorationRecord = {
+                workingCopy: true,
+                indicatorRefreshVersion: 0,
+                indicatorThemeRefreshVersion: 0,
+                icons: { "10": Uri.parse("data:image/svg+xml;base64,b2xk") },
+                blamesByLine: {
+                    "1": { revision: "10", author: "one", date: "2026-02-24", line: "1" },
+                },
+                blamesByRevision: {
+                    "10": [{ revision: "10", author: "one", date: "2026-02-24", line: "1" }],
+                },
+                revisionDecorations: {},
+                logs: {},
+            };
+
+            sandbox.stub(workspace.fs, "stat").resolves();
+            sandbox.stub(window, "visibleTextEditors").value([]);
+            storageMock.get.withArgs(fileName).returns(record);
+            decorationManagerMock.usesThemeAwareIndicatorScheme.returns(true);
+            decorationManagerMock.createGutterIconHashMap.returns({
+                "10": Uri.parse("data:image/svg+xml;base64,bmV3"),
+            });
+            decorationManagerMock.createAndSetDecorationsForBlame.resolves({
+                blamesByLine: record.blamesByLine,
+                blamesByRevision: record.blamesByRevision,
+                revisionDecorations: {},
+            });
+
+            await blamer.refreshThemeAwareVisibleBlameIndicators();
+            await blamer.autoBlame(textEditor);
+
+            assert.ok(
+                decorationManagerMock.createGutterIconHashMap.calledOnceWithExactly(
+                    fileName,
+                    ["10"],
+                    textEditor.document.uri,
+                ),
+            );
+            assert.ok(svnMock.blameFile.notCalled, "uses cached blame data");
+        });
     });
 
     suite("refreshVisibleBlameIndicators", () => {
@@ -541,6 +592,74 @@ suite("Blamer", () => {
             );
             assert.ok(
                 storageMock.set.calledOnceWithExactly(fileName, sinon.match({ icons: newIcons })),
+            );
+            assert.ok(svnMock.blameFile.notCalled, "uses cached blame data");
+        });
+    });
+
+    suite("refreshThemeAwareVisibleBlameIndicators", () => {
+        test("refreshes only theme-aware visible editors from cached blame", async () => {
+            const adaptiveFileName = "/test/adaptive.ts";
+            const unchangedFileName = "/test/unchanged.ts";
+            const createRecord = (): DecorationRecord => ({
+                workingCopy: true,
+                icons: { "10": Uri.parse("data:image/svg+xml;base64,b2xk") },
+                blamesByLine: {
+                    "1": { revision: "10", author: "one", date: "2026-02-24", line: "1" },
+                },
+                blamesByRevision: {
+                    "10": [{ revision: "10", author: "one", date: "2026-02-24", line: "1" }],
+                },
+                revisionDecorations: {},
+                logs: {},
+            });
+            const records = new Map([
+                [adaptiveFileName, createRecord()],
+                [unchangedFileName, createRecord()],
+            ]);
+            const adaptiveEditor = {
+                document: {
+                    fileName: adaptiveFileName,
+                    lineCount: 1,
+                    uri: { fsPath: adaptiveFileName, scheme: "file" },
+                },
+                visibleRanges: [{ start: { line: 0 }, end: { line: 0 } }],
+            } as unknown as TextEditor;
+            const unchangedEditor = {
+                document: {
+                    fileName: unchangedFileName,
+                    lineCount: 1,
+                    uri: { fsPath: unchangedFileName, scheme: "file" },
+                },
+                visibleRanges: [{ start: { line: 0 }, end: { line: 0 } }],
+            } as unknown as TextEditor;
+
+            storageMock.get.callsFake((fileName: string) => records.get(fileName));
+            storageMock.set.callsFake((fileName: string, record: DecorationRecord) =>
+                records.set(fileName, record),
+            );
+            decorationManagerMock.usesThemeAwareIndicatorScheme.callsFake(
+                (resource) => resource.fsPath === adaptiveFileName,
+            );
+            decorationManagerMock.createGutterIconHashMap.returns({
+                "10": Uri.parse("data:image/svg+xml;base64,bmV3"),
+            });
+            decorationManagerMock.createAndSetDecorationsForBlame.resolves({
+                blamesByLine: records.get(adaptiveFileName)!.blamesByLine,
+                blamesByRevision: records.get(adaptiveFileName)!.blamesByRevision,
+                revisionDecorations: {},
+            });
+            sandbox.stub(window, "visibleTextEditors").value([adaptiveEditor, unchangedEditor]);
+            sandbox.stub(workspace, "getConfiguration").returns({ viewportBuffer: 200 } as any);
+
+            await blamer.refreshThemeAwareVisibleBlameIndicators();
+
+            assert.ok(
+                decorationManagerMock.createGutterIconHashMap.calledOnceWithExactly(
+                    adaptiveFileName,
+                    ["10"],
+                    adaptiveEditor.document.uri,
+                ),
             );
             assert.ok(svnMock.blameFile.notCalled, "uses cached blame data");
         });

--- a/src/blamer.ts
+++ b/src/blamer.ts
@@ -30,6 +30,7 @@ export class Blamer {
     private activeLine: string | undefined;
     private activeLineDecoration: TextEditorDecorationType | undefined;
     private indicatorRefreshVersion = 0;
+    private indicatorThemeRefreshVersion = 0;
     private statusBarItem: StatusBarItem;
 
     constructor(
@@ -225,10 +226,42 @@ export class Blamer {
         );
     }
 
+    /**
+     * Recreates theme-aware gutter decorations after the active VS Code theme changes.
+     * This does not run svn blame or replace unaffected colour schemes.
+     */
+    async refreshThemeAwareVisibleBlameIndicators() {
+        const themeRefreshVersion = ++this.indicatorThemeRefreshVersion;
+        const editorsByFileName = new Map<string, TextEditor[]>();
+
+        for (const textEditor of window.visibleTextEditors) {
+            if (!this.decorationManager.usesThemeAwareIndicatorScheme(textEditor.document.uri)) {
+                continue;
+            }
+
+            const fileName = textEditor.document.fileName;
+            const editors = editorsByFileName.get(fileName) ?? [];
+            editors.push(textEditor);
+            editorsByFileName.set(fileName, editors);
+        }
+
+        await Promise.all(
+            [...editorsByFileName].map(([fileName, textEditors]) =>
+                this.refreshVisibleBlameForFile(
+                    fileName,
+                    textEditors,
+                    this.indicatorRefreshVersion,
+                    themeRefreshVersion,
+                ),
+            ),
+        );
+    }
+
     private async refreshVisibleBlameForFile(
         fileName: string,
         textEditors: TextEditor[],
         refreshVersion: number,
+        themeRefreshVersion?: number,
     ) {
         const record = this.getRecordForFile(fileName);
 
@@ -250,6 +283,8 @@ export class Blamer {
 
             if (
                 refreshVersion !== this.indicatorRefreshVersion ||
+                (themeRefreshVersion !== undefined &&
+                    themeRefreshVersion !== this.indicatorThemeRefreshVersion) ||
                 this.getRecordForFile(fileName) !== record
             ) {
                 return;
@@ -266,6 +301,8 @@ export class Blamer {
 
             if (
                 refreshVersion !== this.indicatorRefreshVersion ||
+                (themeRefreshVersion !== undefined &&
+                    themeRefreshVersion !== this.indicatorThemeRefreshVersion) ||
                 this.getRecordForFile(fileName) !== record
             ) {
                 disposeDecorations([...new Set(Object.values(revisionDecorations))]);
@@ -276,6 +313,8 @@ export class Blamer {
                 ...record,
                 icons,
                 indicatorRefreshVersion: refreshVersion,
+                indicatorThemeRefreshVersion:
+                    themeRefreshVersion ?? record.indicatorThemeRefreshVersion,
                 revisionDecorations,
             };
             this.setRecordForFile(fileName, refreshedRecord);
@@ -406,6 +445,7 @@ export class Blamer {
 
         const uniqueRevisions = [...new Set(blame.map(({ revision }) => revision))];
         const iconMapRefreshVersion = this.indicatorRefreshVersion;
+        const iconMapThemeRefreshVersion = this.indicatorThemeRefreshVersion;
         const icons = this.decorationManager.createGutterIconHashMap(
             fileName,
             uniqueRevisions,
@@ -428,17 +468,23 @@ export class Blamer {
             blamesByLine,
             blamesByRevision,
             indicatorRefreshVersion: iconMapRefreshVersion,
+            indicatorThemeRefreshVersion: iconMapThemeRefreshVersion,
             revisionDecorations,
         });
 
         this.statusBarItem.hide();
         this.setRecordForFile(fileName, record);
 
-        if (iconMapRefreshVersion !== this.indicatorRefreshVersion) {
+        if (
+            iconMapRefreshVersion !== this.indicatorRefreshVersion ||
+            (this.decorationManager.usesThemeAwareIndicatorScheme(textEditor.document.uri) &&
+                iconMapThemeRefreshVersion !== this.indicatorThemeRefreshVersion)
+        ) {
             await this.refreshVisibleBlameForFile(
                 fileName,
                 [textEditor],
                 this.indicatorRefreshVersion,
+                this.indicatorThemeRefreshVersion,
             );
         }
 
@@ -508,11 +554,20 @@ export class Blamer {
             }
 
             if (existingRecord) {
-                if (existingRecord.indicatorRefreshVersion !== this.indicatorRefreshVersion) {
+                const refreshesForTheme = this.decorationManager.usesThemeAwareIndicatorScheme(
+                    textEditor.document.uri,
+                );
+                if (
+                    existingRecord.indicatorRefreshVersion !== this.indicatorRefreshVersion ||
+                    (refreshesForTheme &&
+                        existingRecord.indicatorThemeRefreshVersion !==
+                            this.indicatorThemeRefreshVersion)
+                ) {
                     await this.refreshVisibleBlameForFile(
                         fileName,
                         [textEditor],
                         this.indicatorRefreshVersion,
+                        refreshesForTheme ? this.indicatorThemeRefreshVersion : undefined,
                     );
                     return;
                 }

--- a/src/decoration-manager.spec.ts
+++ b/src/decoration-manager.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { Range, TextEditor, TextEditorDecorationType, Uri } from "vscode";
+import { ColorThemeKind, Range, TextEditor, TextEditorDecorationType, Uri } from "vscode";
 
 import { EXTENSION_CONFIGURATION } from "./const/extension";
 import { MAX_NUMBER } from "./const/number";
@@ -101,12 +101,43 @@ suite("DecorationManager", () => {
 
         assert.match(decodeSvg(icons["10"]), /fill="rgb\(255\.0000, 255\.0000, 255\.0000\)"/);
         assert.match(decodeSvg(icons["30"]), /fill="rgb\(31\.0000, 95\.0000, 159\.0000\)"/);
+        assert.doesNotMatch(decodeSvg(icons["10"]), /stroke=/);
         assert.ok(
             getConfigurationStub.calledWith(
                 EXTENSION_CONFIGURATION,
                 sinon.match({ fsPath: "/workspace/example.ts" }),
             ),
         );
+    });
+
+    test("outlines built-in indicators only in light themes", async () => {
+        const vscode = require("vscode");
+        const activeColorTheme = { kind: ColorThemeKind.Light };
+        sandbox.stub(vscode.window, "activeColorTheme").value(activeColorTheme);
+        getConfigurationStub.returns({
+            enableVisualIndicators: true,
+            indicatorColorScheme: "blue",
+        });
+
+        for (const themeKind of [ColorThemeKind.Light, ColorThemeKind.HighContrastLight]) {
+            activeColorTheme.kind = themeKind;
+            const icons = await decorationManager.createGutterIconHashMap("/workspace/example.ts", [
+                "10",
+            ]);
+            const svg = Buffer.from(String(icons["10"]).split(",")[1], "base64").toString("utf8");
+
+            assert.match(svg, /stroke="#475569" stroke-width="7"/);
+        }
+
+        for (const themeKind of [ColorThemeKind.Dark, ColorThemeKind.HighContrast]) {
+            activeColorTheme.kind = themeKind;
+            const icons = await decorationManager.createGutterIconHashMap("/workspace/example.ts", [
+                "10",
+            ]);
+            const svg = Buffer.from(String(icons["10"]).split(",")[1], "base64").toString("utf8");
+
+            assert.doesNotMatch(svg, /stroke=/);
+        }
     });
 
     test("uses the original document URI to resolve indicator settings", async () => {
@@ -174,10 +205,18 @@ suite("DecorationManager", () => {
     test("uses SVG data URIs for every chronological colour scheme", async () => {
         decorationManager = new DecorationManager();
 
-        for (const scheme of ["redToGreen", "blue", "teal", "violet", "vermilion"] as const) {
+        for (const scheme of [
+            "redToGreen",
+            "blue",
+            "teal",
+            "violet",
+            "vermilion",
+            "custom",
+        ] as const) {
             getConfigurationStub.returns({
                 enableVisualIndicators: true,
                 indicatorColorScheme: scheme,
+                get: () => "#123456",
             });
 
             const icons = await decorationManager.createGutterIconHashMap("/workspace/example.ts", [
@@ -188,6 +227,51 @@ suite("DecorationManager", () => {
             assert.match(String(icons["10"]), /^data:image\/svg\+xml;base64,/);
             assert.match(String(icons["20"]), /^data:image\/svg\+xml;base64,/);
         }
+    });
+
+    test("uses custom colours and falls back per invalid endpoint", async () => {
+        getConfigurationStub.returns({
+            enableVisualIndicators: true,
+            indicatorColorScheme: "custom",
+            get: (key: string) => {
+                if (key === "indicatorCustomOldestColor") {
+                    return "not-a-colour";
+                }
+                if (key === "indicatorCustomNewestColor") {
+                    return "#ABCDEF";
+                }
+                return "#654321";
+            },
+        });
+        decorationManager = new DecorationManager();
+
+        const icons = await decorationManager.createGutterIconHashMap("/workspace/example.ts", [
+            "10",
+            "20",
+        ]);
+        const decodeSvg = (icon: unknown) =>
+            Buffer.from(String(icon).split(",")[1], "base64").toString("utf8");
+
+        assert.match(decodeSvg(icons["10"]), /fill="rgb\(107\.0000, 114\.0000, 128\.0000\)"/);
+        assert.match(decodeSvg(icons["20"]), /fill="rgb\(171\.0000, 205\.0000, 239\.0000\)"/);
+        assert.match(decodeSvg(icons["10"]), /stroke="#654321" stroke-width="7"/);
+    });
+
+    test("identifies only the adaptive single-colour schemes as theme-aware", () => {
+        getConfigurationStub.returns({ indicatorColorScheme: "blue" });
+        assert.ok(
+            decorationManager.usesThemeAwareIndicatorScheme(Uri.file("/workspace/example.ts")),
+        );
+
+        getConfigurationStub.returns({ indicatorColorScheme: "custom" });
+        assert.ok(
+            !decorationManager.usesThemeAwareIndicatorScheme(Uri.file("/workspace/example.ts")),
+        );
+
+        getConfigurationStub.returns({ indicatorColorScheme: "redToGreen" });
+        assert.ok(
+            !decorationManager.usesThemeAwareIndicatorScheme(Uri.file("/workspace/example.ts")),
+        );
     });
 
     test("keeps contrast-first random icons stable for a file", async () => {

--- a/src/decoration-manager.ts
+++ b/src/decoration-manager.ts
@@ -17,12 +17,18 @@ import {
     createChronologicalIconMapFromFactory,
     createRandomIconMapFromItems,
     createRandomIconOrderFromFactory,
+    getCustomIndicatorGradient,
+    getCustomIndicatorOutline,
     getIndicatorColorScheme,
+    isThemeAwareIndicatorColorScheme,
 } from "./indicator-colors";
 import {
+    getBuiltInIndicatorGradient,
     getChronologicalIndicatorUri,
     getRandomIndicatorUri,
     INDICATOR_COUNT,
+    LIGHT_INDICATOR_OUTLINE,
+    usesLightThemeIndicatorOutline,
 } from "./indicator-uris";
 import { mapBlameToHoverMessage } from "./mapping/map-blame-to-hover-message";
 import { mapBlameToInlineMessage } from "./mapping/map-blame-to-inline-message";
@@ -32,6 +38,13 @@ import { GutterIconHashMap } from "./types/gutter-icon-hash-map.model";
 import { LogHashMap } from "./types/log-hash-map.model";
 
 export class DecorationManager {
+    usesThemeAwareIndicatorScheme(resource: Uri): boolean {
+        const configuration = workspace.getConfiguration(EXTENSION_CONFIGURATION, resource);
+        return isThemeAwareIndicatorColorScheme(
+            getIndicatorColorScheme(configuration.indicatorColorScheme),
+        );
+    }
+
     createGutterDecorationType(gutterIconImage?: Uri): TextEditorDecorationType {
         return window.createTextEditorDecorationType({
             gutterIconPath: gutterIconImage,
@@ -164,8 +177,26 @@ export class DecorationManager {
         const scheme = getIndicatorColorScheme(configuration.indicatorColorScheme);
 
         if (scheme !== "random") {
+            const themeKind = window.activeColorTheme.kind;
+            const gradient =
+                scheme === "custom"
+                    ? getCustomIndicatorGradient(
+                          configuration.get("indicatorCustomOldestColor"),
+                          configuration.get("indicatorCustomNewestColor"),
+                      )
+                    : isThemeAwareIndicatorColorScheme(scheme)
+                      ? getBuiltInIndicatorGradient(scheme)
+                      : undefined;
+            const outline =
+                scheme === "custom"
+                    ? getCustomIndicatorOutline(configuration.get("indicatorCustomOutlineColor"))
+                    : isThemeAwareIndicatorColorScheme(scheme) &&
+                        usesLightThemeIndicatorOutline(themeKind)
+                      ? LIGHT_INDICATOR_OUTLINE
+                      : undefined;
+
             return createChronologicalIconMapFromFactory(revisions, INDICATOR_COUNT, (index) =>
-                getChronologicalIndicatorUri(scheme, index),
+                getChronologicalIndicatorUri(scheme, index, gradient, outline),
             );
         }
 

--- a/src/extension-configuration.spec.ts
+++ b/src/extension-configuration.spec.ts
@@ -15,6 +15,9 @@ type ExtensionPackage = {
                     markdownDescription?: string;
                     order?: number;
                     scope?: unknown;
+                    format?: string;
+                    pattern?: string;
+                    title?: string;
                 }
             >;
         };
@@ -36,6 +39,7 @@ suite("Extension configuration", () => {
             "teal",
             "violet",
             "vermilion",
+            "custom",
         ]);
         assert.deepStrictEqual(properties["svnBlamer.indicatorColorScheme"]?.enumItemLabels, [
             "Random",
@@ -44,8 +48,41 @@ suite("Extension configuration", () => {
             "Teal",
             "Violet",
             "Vermilion",
+            "Custom gradient",
         ]);
         assert.strictEqual(properties["svnBlamer.indicatorColorScheme"]?.order, 4);
+        assert.deepStrictEqual(properties["svnBlamer.indicatorCustomOldestColor"], {
+            scope: "resource",
+            order: 5,
+            title: "Oldest commit colour",
+            default: "#6b7280",
+            description:
+                "Used only with Custom gradient. Enter an opaque #RRGGBB colour. This exact value does not adapt to the active theme, so use enough contrast.",
+            type: "string",
+            format: "color-hex",
+            pattern: "^#[0-9a-fA-F]{6}$",
+        });
+        assert.deepStrictEqual(properties["svnBlamer.indicatorCustomNewestColor"], {
+            scope: "resource",
+            order: 6,
+            title: "Newest commit colour",
+            default: "#1f5f9f",
+            description:
+                "Used only with Custom gradient. Enter an opaque #RRGGBB colour. This exact value does not adapt to the active theme, so use enough contrast.",
+            type: "string",
+            format: "color-hex",
+            pattern: "^#[0-9a-fA-F]{6}$",
+        });
+        assert.deepStrictEqual(properties["svnBlamer.indicatorCustomOutlineColor"], {
+            scope: "resource",
+            order: 7,
+            title: "Custom indicator outline colour",
+            default: "",
+            description:
+                "Used only with Custom gradient. Optionally enter an opaque #RRGGBB colour to outline each indicator. Leave blank for no outline.",
+            type: "string",
+            pattern: "^(|#[0-9a-fA-F]{6})$",
+        });
         assert.strictEqual(properties["svnBlamer.indicatorColorPalette"], undefined);
         assert.strictEqual(properties["svnBlamer.indicatorColorContrast"], undefined);
     });

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -1,15 +1,19 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import {
+    ColorTheme,
+    ColorThemeKind,
     commands,
     ConfigurationChangeEvent,
     Disposable,
     ExtensionContext,
+    window,
     workspace,
 } from "vscode";
 
 import { Blamer } from "./blamer";
 import { activate } from "./extension";
+import * as indicatorUris from "./indicator-uris";
 
 suite("Extension", () => {
     const sandbox = sinon.createSandbox();
@@ -20,11 +24,18 @@ suite("Extension", () => {
 
     test("refreshes indicators after the colour scheme configuration change settles", async () => {
         let configurationListener: ((event: ConfigurationChangeEvent) => void) | undefined;
+        let themeListener: ((theme: ColorTheme) => void) | undefined;
         const refresh = sandbox.stub(Blamer.prototype, "refreshVisibleBlameIndicators").resolves();
+        sandbox.stub(Blamer.prototype, "refreshThemeAwareVisibleBlameIndicators").resolves();
+        const clearCache = sandbox.stub(indicatorUris, "clearIndicatorUriCache");
 
         sandbox.stub(commands, "registerCommand").returns({ dispose: () => {} } as Disposable);
         sandbox.stub(workspace, "onDidChangeConfiguration").callsFake((listener) => {
             configurationListener = listener;
+            return { dispose: () => {} } as Disposable;
+        });
+        sandbox.stub(window, "onDidChangeActiveColorTheme").callsFake((listener) => {
+            themeListener = listener;
             return { dispose: () => {} } as Disposable;
         });
 
@@ -39,5 +50,60 @@ suite("Extension", () => {
         await new Promise<void>((resolve) => queueMicrotask(resolve));
 
         assert.ok(refresh.calledOnce);
+        assert.ok(clearCache.calledOnce);
+        assert.ok(themeListener, "registers a theme change listener");
+    });
+
+    test("refreshes indicators when a custom colour setting changes", async () => {
+        let configurationListener: ((event: ConfigurationChangeEvent) => void) | undefined;
+        const refresh = sandbox.stub(Blamer.prototype, "refreshVisibleBlameIndicators").resolves();
+        sandbox.stub(Blamer.prototype, "refreshThemeAwareVisibleBlameIndicators").resolves();
+        sandbox.stub(indicatorUris, "clearIndicatorUriCache");
+        sandbox.stub(commands, "registerCommand").returns({ dispose: () => {} } as Disposable);
+        sandbox.stub(workspace, "onDidChangeConfiguration").callsFake((listener) => {
+            configurationListener = listener;
+            return { dispose: () => {} } as Disposable;
+        });
+        sandbox
+            .stub(window, "onDidChangeActiveColorTheme")
+            .returns({ dispose: () => {} } as Disposable);
+
+        await activate({ subscriptions: [] } as unknown as ExtensionContext);
+
+        for (const setting of [
+            "svnBlamer.indicatorCustomOldestColor",
+            "svnBlamer.indicatorCustomNewestColor",
+            "svnBlamer.indicatorCustomOutlineColor",
+        ]) {
+            configurationListener?.({
+                affectsConfiguration: (section: string) => section === setting,
+            } as ConfigurationChangeEvent);
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+        }
+
+        assert.strictEqual(refresh.callCount, 3);
+    });
+
+    test("refreshes only theme-aware indicators when the active theme changes", async () => {
+        let themeListener: ((theme: ColorTheme) => void) | undefined;
+        sandbox.stub(Blamer.prototype, "refreshVisibleBlameIndicators").resolves();
+        const refreshThemeAware = sandbox
+            .stub(Blamer.prototype, "refreshThemeAwareVisibleBlameIndicators")
+            .resolves();
+        const clearCache = sandbox.stub(indicatorUris, "clearIndicatorUriCache");
+        sandbox.stub(commands, "registerCommand").returns({ dispose: () => {} } as Disposable);
+        sandbox
+            .stub(workspace, "onDidChangeConfiguration")
+            .returns({ dispose: () => {} } as Disposable);
+        sandbox.stub(window, "onDidChangeActiveColorTheme").callsFake((listener) => {
+            themeListener = listener;
+            return { dispose: () => {} } as Disposable;
+        });
+
+        await activate({ subscriptions: [] } as unknown as ExtensionContext);
+        themeListener?.({ kind: ColorThemeKind.Dark });
+
+        assert.ok(refreshThemeAware.calledOnce);
+        assert.ok(clearCache.calledOnce);
     });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { Blamer } from "./blamer";
 import { EXTENSION_NAME } from "./const/extension";
 import { CredentialManager } from "./credential-manager";
 import { DecorationManager } from "./decoration-manager";
+import { clearIndicatorUriCache } from "./indicator-uris";
 import { Storage } from "./storage";
 import { SVN } from "./svn";
 import { DecorationRecord } from "./types/decoration-record.model";
@@ -45,9 +46,20 @@ export async function activate(context: ExtensionContext) {
     );
 
     const updateIndicatorColours = workspace.onDidChangeConfiguration((event) => {
-        if (event.affectsConfiguration("svnBlamer.indicatorColorScheme")) {
+        if (
+            event.affectsConfiguration("svnBlamer.indicatorColorScheme") ||
+            event.affectsConfiguration("svnBlamer.indicatorCustomOldestColor") ||
+            event.affectsConfiguration("svnBlamer.indicatorCustomNewestColor") ||
+            event.affectsConfiguration("svnBlamer.indicatorCustomOutlineColor")
+        ) {
+            clearIndicatorUriCache();
             queueMicrotask(() => void blamer.refreshVisibleBlameIndicators());
         }
+    });
+
+    const updateThemeAwareIndicatorColours = window.onDidChangeActiveColorTheme(() => {
+        clearIndicatorUriCache();
+        void blamer.refreshThemeAwareVisibleBlameIndicators();
     });
 
     const clearOnClose = workspace.onDidCloseTextDocument((textDocument) =>
@@ -75,6 +87,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(scrollUpdate);
     context.subscriptions.push(autoBlame);
     context.subscriptions.push(updateIndicatorColours);
+    context.subscriptions.push(updateThemeAwareIndicatorColours);
     context.subscriptions.push(clearCredentials);
     context.subscriptions.push(logger);
     context.subscriptions.push(blamer);

--- a/src/indicator-colors.spec.ts
+++ b/src/indicator-colors.spec.ts
@@ -4,6 +4,9 @@ import {
     createChronologicalIconMap,
     createRandomIconMap,
     createRandomIconOrder,
+    DEFAULT_CUSTOM_INDICATOR_GRADIENT,
+    getCustomIndicatorGradient,
+    getCustomIndicatorOutline,
     getIndicatorColorScheme,
     INDICATOR_COLOR_PALETTES,
     sortRevisions,
@@ -28,6 +31,30 @@ suite("Indicator colours", () => {
     test("falls back to safe indicator settings for invalid configuration values", () => {
         assert.strictEqual(getIndicatorColorScheme("unexpected"), "random");
         assert.strictEqual(getIndicatorColorScheme("greenToRed"), "random");
+    });
+
+    test("uses safe defaults for each invalid custom gradient endpoint", () => {
+        assert.deepStrictEqual(getCustomIndicatorGradient("#ABCDEF", "not-a-colour"), {
+            oldest: "#abcdef",
+            newest: DEFAULT_CUSTOM_INDICATOR_GRADIENT.newest,
+        });
+        assert.deepStrictEqual(getCustomIndicatorGradient(undefined, "#123456"), {
+            oldest: DEFAULT_CUSTOM_INDICATOR_GRADIENT.oldest,
+            newest: "#123456",
+        });
+    });
+
+    test("allows equal custom gradient endpoints for a single-colour scheme", () => {
+        assert.deepStrictEqual(getCustomIndicatorGradient("#123456", "#123456"), {
+            oldest: "#123456",
+            newest: "#123456",
+        });
+    });
+
+    test("uses an optional valid custom outline and ignores invalid values", () => {
+        assert.strictEqual(getCustomIndicatorOutline("#ABCDEF"), "#abcdef");
+        assert.strictEqual(getCustomIndicatorOutline(""), undefined);
+        assert.strictEqual(getCustomIndicatorOutline("not-a-colour"), undefined);
     });
 
     test("maps chronological revisions from oldest to newest", () => {

--- a/src/indicator-colors.ts
+++ b/src/indicator-colors.ts
@@ -5,17 +5,51 @@ export const INDICATOR_COLOR_SCHEMES = [
     "teal",
     "violet",
     "vermilion",
+    "custom",
 ] as const;
 export const INDICATOR_COLOR_PALETTES = ["blue", "teal", "violet", "vermilion"] as const;
 
 export type IndicatorColorScheme = (typeof INDICATOR_COLOR_SCHEMES)[number];
 export type IndicatorColorPalette = (typeof INDICATOR_COLOR_PALETTES)[number];
 export type ChronologicalColorScheme = Exclude<IndicatorColorScheme, "random">;
+export type ThemeAwareIndicatorColorScheme = IndicatorColorPalette;
+
+export type IndicatorGradient = Readonly<{
+    oldest: string;
+    newest: string;
+}>;
+
+export const DEFAULT_CUSTOM_INDICATOR_GRADIENT: IndicatorGradient = {
+    oldest: "#6b7280",
+    newest: "#1f5f9f",
+};
 
 export const getIndicatorColorScheme = (value: unknown): IndicatorColorScheme =>
     INDICATOR_COLOR_SCHEMES.includes(value as IndicatorColorScheme)
         ? (value as IndicatorColorScheme)
         : "random";
+
+export const isThemeAwareIndicatorColorScheme = (
+    scheme: IndicatorColorScheme,
+): scheme is ThemeAwareIndicatorColorScheme =>
+    INDICATOR_COLOR_PALETTES.includes(scheme as IndicatorColorPalette);
+
+const isHexColour = (value: unknown): value is string =>
+    typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+
+const getHexColourOrDefault = (value: unknown, defaultValue: string): string =>
+    isHexColour(value) ? value.toLowerCase() : defaultValue;
+
+export const getCustomIndicatorGradient = (
+    oldest: unknown,
+    newest: unknown,
+): IndicatorGradient => ({
+    oldest: getHexColourOrDefault(oldest, DEFAULT_CUSTOM_INDICATOR_GRADIENT.oldest),
+    newest: getHexColourOrDefault(newest, DEFAULT_CUSTOM_INDICATOR_GRADIENT.newest),
+});
+
+export const getCustomIndicatorOutline = (value: unknown): string | undefined =>
+    isHexColour(value) ? value.toLowerCase() : undefined;
 
 const hashString = (value: string): number => {
     let hash = 2166136261;

--- a/src/indicator-uris.spec.ts
+++ b/src/indicator-uris.spec.ts
@@ -1,24 +1,42 @@
 import * as assert from "assert";
+import { ColorThemeKind } from "vscode";
 
-import { INDICATOR_COLOR_PALETTES } from "./indicator-colors";
+import { DEFAULT_CUSTOM_INDICATOR_GRADIENT, INDICATOR_COLOR_PALETTES } from "./indicator-colors";
 import {
+    clearIndicatorUriCache,
+    getBuiltInIndicatorGradient,
     getChronologicalIndicatorUri,
     getRandomIndicatorUri,
     INDICATOR_COUNT,
+    LIGHT_INDICATOR_OUTLINE,
+    usesLightThemeIndicatorOutline,
 } from "./indicator-uris";
 
 const decodeSvg = (uri: unknown): string =>
     Buffer.from(String(uri).split(",")[1], "base64").toString("utf8");
 
-suite("Indicator URIs", () => {
-    test("preserves the chronological endpoint colours", () => {
-        const expectedStrongColours = {
-            blue: "rgb(31.0000, 95.0000, 159.0000)",
-            teal: "rgb(0.0000, 115.0000, 93.0000)",
-            violet: "rgb(111.0000, 75.0000, 156.0000)",
-            vermilion: "rgb(158.0000, 63.0000, 19.0000)",
-        } as const;
+const getRgbFill = (uri: unknown): number[] => {
+    const match = /fill="rgb\(([^)]+)\)"/.exec(decodeSvg(uri));
+    assert.ok(match, "indicator should contain an RGB fill colour");
+    return match[1].split(", ").map(Number);
+};
 
+const hexToRgb = (hex: string): number[] => [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+];
+
+const assertRgbApproximately = (actual: number[], expected: number[]) => {
+    for (const [index, value] of expected.entries()) {
+        assert.ok(Math.abs(actual[index] - value) < 0.01, `component ${index} should match`);
+    }
+};
+
+suite("Indicator URIs", () => {
+    teardown(() => clearIndicatorUriCache());
+
+    test("keeps the red to green scheme from oldest to newest", () => {
         assert.match(
             decodeSvg(getChronologicalIndicatorUri("redToGreen", 0)),
             /fill="hsl\(0\.0000, 68\.0000%, 45\.0000%\)"/,
@@ -27,18 +45,72 @@ suite("Indicator URIs", () => {
             decodeSvg(getChronologicalIndicatorUri("redToGreen", INDICATOR_COUNT - 1)),
             /fill="hsl\(142\.0000, 62\.0000%, 38\.0000%\)"/,
         );
+    });
 
+    test("uses shared endpoints for each built-in single-colour scheme", () => {
         for (const palette of INDICATOR_COLOR_PALETTES) {
-            assert.match(
-                decodeSvg(getChronologicalIndicatorUri(palette, 0)),
-                /fill="rgb\(255\.0000, 255\.0000, 255\.0000\)"/,
+            const gradient = getBuiltInIndicatorGradient(palette);
+            assertRgbApproximately(
+                getRgbFill(getChronologicalIndicatorUri(palette, 0, gradient)),
+                hexToRgb(gradient.oldest),
             );
-            assert.ok(
-                decodeSvg(getChronologicalIndicatorUri(palette, INDICATOR_COUNT - 1)).includes(
-                    `fill="${expectedStrongColours[palette]}"`,
-                ),
+            assertRgbApproximately(
+                getRgbFill(getChronologicalIndicatorUri(palette, INDICATOR_COUNT - 1, gradient)),
+                hexToRgb(gradient.newest),
             );
         }
+    });
+
+    test("uses the custom gradient exactly from oldest to newest", () => {
+        const gradient = { oldest: "#123456", newest: "#abcdef" };
+
+        assertRgbApproximately(
+            getRgbFill(getChronologicalIndicatorUri("custom", 0, gradient)),
+            hexToRgb(gradient.oldest),
+        );
+        assertRgbApproximately(
+            getRgbFill(getChronologicalIndicatorUri("custom", INDICATOR_COUNT - 1, gradient)),
+            hexToRgb(gradient.newest),
+        );
+    });
+
+    test("outlines built-in single-colour indicators only for light themes", () => {
+        const gradient = getBuiltInIndicatorGradient("blue");
+        const outlined = getChronologicalIndicatorUri("blue", 0, gradient, LIGHT_INDICATOR_OUTLINE);
+        const plain = getChronologicalIndicatorUri("blue", 0, gradient);
+
+        assert.match(decodeSvg(outlined), /stroke="#475569" stroke-width="7"/);
+        assert.doesNotMatch(decodeSvg(plain), /stroke=/);
+        assert.ok(usesLightThemeIndicatorOutline(ColorThemeKind.Light));
+        assert.ok(usesLightThemeIndicatorOutline(ColorThemeKind.HighContrastLight));
+        assert.ok(!usesLightThemeIndicatorOutline(ColorThemeKind.Dark));
+        assert.ok(!usesLightThemeIndicatorOutline(ColorThemeKind.HighContrast));
+    });
+
+    test("uses OKLab interpolation for custom gradients", () => {
+        const midpoint = getRgbFill(
+            getChronologicalIndicatorUri("custom", Math.floor((INDICATOR_COUNT - 1) / 2), {
+                oldest: "#6b7280",
+                newest: "#1f5f9f",
+            }),
+        );
+
+        assert.notDeepStrictEqual(midpoint, [69, 104, 143], "does not use direct RGB mixing");
+    });
+
+    test("clears cached SVG URIs when a colour input changes", () => {
+        const first = getChronologicalIndicatorUri("custom", 0, DEFAULT_CUSTOM_INDICATOR_GRADIENT);
+        const cached = getChronologicalIndicatorUri("custom", 0, DEFAULT_CUSTOM_INDICATOR_GRADIENT);
+
+        clearIndicatorUriCache();
+
+        const regenerated = getChronologicalIndicatorUri(
+            "custom",
+            0,
+            DEFAULT_CUSTOM_INDICATOR_GRADIENT,
+        );
+        assert.strictEqual(first, cached);
+        assert.notStrictEqual(first, regenerated);
     });
 
     test("preserves the random palette endpoint colours", () => {
@@ -50,10 +122,6 @@ suite("Indicator URIs", () => {
         } as const;
 
         for (const palette of INDICATOR_COLOR_PALETTES) {
-            assert.strictEqual(
-                getRandomIndicatorUri(palette, 0),
-                getChronologicalIndicatorUri(palette, INDICATOR_COUNT - 1),
-            );
             assert.ok(
                 decodeSvg(getRandomIndicatorUri(palette, INDICATOR_COUNT - 1)).includes(
                     `fill="${expectedPaleColours[palette]}"`,

--- a/src/indicator-uris.ts
+++ b/src/indicator-uris.ts
@@ -1,6 +1,12 @@
-import { Uri } from "vscode";
+import { ColorThemeKind, Uri } from "vscode";
 
-import { ChronologicalColorScheme, IndicatorColorPalette } from "./indicator-colors";
+import {
+    ChronologicalColorScheme,
+    INDICATOR_COLOR_PALETTES,
+    IndicatorColorPalette,
+    IndicatorGradient,
+    ThemeAwareIndicatorColorScheme,
+} from "./indicator-colors";
 
 export const INDICATOR_COUNT = 500;
 
@@ -13,34 +19,129 @@ const PALETTE_ENDPOINTS: Record<IndicatorColorPalette, readonly [string, string]
     vermilion: ["#9e3f13", "#de855d"],
 };
 
+export const LIGHT_INDICATOR_OUTLINE = "#475569";
+
+const BUILT_IN_GRADIENTS = Object.fromEntries(
+    INDICATOR_COLOR_PALETTES.map((palette) => [
+        palette,
+        { oldest: "#ffffff", newest: PALETTE_ENDPOINTS[palette][0] },
+    ]),
+) as Record<ThemeAwareIndicatorColorScheme, IndicatorGradient>;
+
 const hexToRgb = (hex: string): readonly number[] => [
     Number.parseInt(hex.slice(1, 3), 16),
     Number.parseInt(hex.slice(3, 5), 16),
     Number.parseInt(hex.slice(5, 7), 16),
 ];
 
-const interpolateColor = (start: readonly number[], end: readonly number[], ratio: number) => {
+const interpolateRgb = (start: readonly number[], end: readonly number[], ratio: number) => {
     const values = start.map((value, index) => value + (end[index] - value) * ratio);
     return `rgb(${values.map((value) => value.toFixed(4)).join(", ")})`;
 };
 
-const createIndicatorUri = (color: string): Uri => {
-    const cached = uriCache.get(color);
+const clamp = (value: number, minimum = 0, maximum = 1): number =>
+    Math.min(Math.max(value, minimum), maximum);
+
+const srgbToLinear = (value: number): number => {
+    const normalised = value / 255;
+    return normalised <= 0.04045 ? normalised / 12.92 : ((normalised + 0.055) / 1.055) ** 2.4;
+};
+
+const linearToSrgb = (value: number): number => {
+    const normalised = value <= 0.0031308 ? value * 12.92 : 1.055 * value ** (1 / 2.4) - 0.055;
+    return clamp(normalised) * 255;
+};
+
+type Oklab = readonly [number, number, number];
+type OklabGradient = Readonly<{ start: Oklab; end: Oklab }>;
+
+const oklabGradientCache = new Map<string, OklabGradient>();
+
+const rgbToOklab = (hex: string): Oklab => {
+    const [red, green, blue] = hexToRgb(hex).map(srgbToLinear);
+    const l = 0.4122214708 * red + 0.5363325363 * green + 0.0514459929 * blue;
+    const m = 0.2119034982 * red + 0.6806995451 * green + 0.1073969566 * blue;
+    const s = 0.0883024619 * red + 0.2817188376 * green + 0.6299787005 * blue;
+    const lRoot = Math.cbrt(l);
+    const mRoot = Math.cbrt(m);
+    const sRoot = Math.cbrt(s);
+
+    return [
+        0.2104542553 * lRoot + 0.793617785 * mRoot - 0.0040720468 * sRoot,
+        1.9779984951 * lRoot - 2.428592205 * mRoot + 0.4505937099 * sRoot,
+        0.0259040371 * lRoot + 0.7827717662 * mRoot - 0.808675766 * sRoot,
+    ];
+};
+
+const oklabToRgb = ([lightness, a, b]: Oklab): readonly number[] => {
+    const l = (lightness + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+    const m = (lightness - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+    const s = (lightness - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+    return [
+        linearToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+        linearToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+        linearToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+    ];
+};
+
+const getOklabGradient = (start: string, end: string): OklabGradient => {
+    const cacheKey = `${start}:${end}`;
+    const cached = oklabGradientCache.get(cacheKey);
     if (cached) {
         return cached;
     }
 
-    const svg = `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" fill="${color}" r="30"/></svg>`;
+    const gradient = { start: rgbToOklab(start), end: rgbToOklab(end) };
+    oklabGradientCache.set(cacheKey, gradient);
+    return gradient;
+};
+
+const interpolateOklab = (start: string, end: string, ratio: number): string => {
+    const { start: startOklab, end: endOklab } = getOklabGradient(start, end);
+    const interpolated: Oklab = [
+        startOklab[0] + (endOklab[0] - startOklab[0]) * ratio,
+        startOklab[1] + (endOklab[1] - startOklab[1]) * ratio,
+        startOklab[2] + (endOklab[2] - startOklab[2]) * ratio,
+    ];
+    return `rgb(${oklabToRgb(interpolated)
+        .map((value) => value.toFixed(4))
+        .join(", ")})`;
+};
+
+const createIndicatorUri = (color: string, outline?: string): Uri => {
+    const cacheKey = `${color}:${outline ?? ""}`;
+    const cached = uriCache.get(cacheKey);
+    if (cached) {
+        return cached;
+    }
+
+    const stroke = outline ? ` stroke="${outline}" stroke-width="7"` : "";
+    const svg = `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" fill="${color}" r="30"${stroke}/></svg>`;
     const uri = Uri.parse(`data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`);
-    uriCache.set(color, uri);
+    uriCache.set(cacheKey, uri);
     return uri;
 };
 
-const indexToRatio = (index: number): number => index / (INDICATOR_COUNT - 1);
+export const clearIndicatorUriCache = (): void => {
+    uriCache.clear();
+    oklabGradientCache.clear();
+};
+
+const indexToRatio = (index: number): number => clamp(index / (INDICATOR_COUNT - 1));
+
+export const getBuiltInIndicatorGradient = (
+    scheme: ThemeAwareIndicatorColorScheme,
+): IndicatorGradient => BUILT_IN_GRADIENTS[scheme];
+
+export const usesLightThemeIndicatorOutline = (themeKind: ColorThemeKind): boolean =>
+    themeKind === ColorThemeKind.Light || themeKind === ColorThemeKind.HighContrastLight;
 
 export const getChronologicalIndicatorUri = (
     scheme: ChronologicalColorScheme,
     index: number,
+    gradient?: IndicatorGradient,
+    outline?: string,
 ): Uri => {
     const ratio = indexToRatio(index);
 
@@ -53,13 +154,16 @@ export const getChronologicalIndicatorUri = (
         );
     }
 
-    const [strong] = PALETTE_ENDPOINTS[scheme];
-    return createIndicatorUri(interpolateColor([255, 255, 255], hexToRgb(strong), ratio));
+    if (!gradient) {
+        throw new Error(`A gradient is required for ${scheme} indicator colours.`);
+    }
+
+    return createIndicatorUri(interpolateOklab(gradient.oldest, gradient.newest, ratio), outline);
 };
 
 export const getRandomIndicatorUri = (palette: IndicatorColorPalette, index: number): Uri => {
     const [strong, pale] = PALETTE_ENDPOINTS[palette];
     return createIndicatorUri(
-        interpolateColor(hexToRgb(strong), hexToRgb(pale), indexToRatio(index)),
+        interpolateRgb(hexToRgb(strong), hexToRgb(pale), indexToRatio(index)),
     );
 };

--- a/src/mapping/map-to-decoration-record.ts
+++ b/src/mapping/map-to-decoration-record.ts
@@ -8,6 +8,7 @@ const defaultRecord: DecorationRecord = {
     logs: {},
     workingCopy: true,
     indicatorRefreshVersion: 0,
+    indicatorThemeRefreshVersion: 0,
 };
 
 export const mapToDecorationRecord = (

--- a/src/test/mock-vscode.ts
+++ b/src/test/mock-vscode.ts
@@ -21,8 +21,10 @@ const vscodeMock = {
             text: "",
         }),
         activeTextEditor: undefined,
+        activeColorTheme: { kind: 2 },
         visibleTextEditors: [],
         onDidChangeActiveTextEditor: () => ({ dispose: () => {} }),
+        onDidChangeActiveColorTheme: () => ({ dispose: () => {} }),
         onDidChangeTextEditorSelection: () => ({ dispose: () => {} }),
         onDidChangeTextEditorVisibleRanges: () => ({ dispose: () => {} }),
         showWarningMessage: () => {},
@@ -62,6 +64,7 @@ const vscodeMock = {
         ) {}
     },
     DecorationRangeBehavior: { ClosedClosed: 0 },
+    ColorThemeKind: { Light: 1, Dark: 2, HighContrast: 3, HighContrastLight: 4 },
     StatusBarAlignment: { Left: 1, Right: 2 },
     extensions: {
         getExtension: () => ({ extensionPath: "/test/path" }),

--- a/src/types/decoration-record.model.ts
+++ b/src/types/decoration-record.model.ts
@@ -22,4 +22,5 @@ export type DecorationRecord = {
     logs: LogHashMap;
     workingCopy: boolean;
     indicatorRefreshVersion?: number;
+    indicatorThemeRefreshVersion?: number;
 };


### PR DESCRIPTION
References #695

## Context for reviewers

PR #702 introduced runtime SVG indicator URIs and the first chronological schemes. This follow-up makes those chronological indicators visible on both light and dark workbench themes, and lets users define a complete custom gradient.

## What changed

- keep the built-in Blue, Teal, Violet, and Vermilion gradients consistent: white for oldest revisions and the established strong palette colour for newest revisions
- add a thin outline for those built-ins only in Light and High Contrast Light themes, so white oldest dots remain visible
- add a Custom gradient scheme with resource-scoped oldest, newest, and optional outline colours
- validate custom hexadecimal values with safe runtime fallbacks, and refresh cached visible indicators after relevant setting or theme changes without running SVN blame
- clear obsolete SVG and OKLab caches on relevant changes; cache OKLab endpoints per gradient
- require VS Code 1.66 to distinguish High Contrast Light
- document the settings and add coverage for configuration, refresh, cache, and theme behavior

## Intentionally out of scope

- Random and Red → Green retain their established behaviour.
- Custom colours are exact values, not theme-derived; users choose sufficient contrast.
- This PR references #695 but does not close it. The issue will be closed with the later release.

## Validation

- `pnpm run compile-tests`
- `pnpm lint`
- `pnpm test:unit` — 160 passing
- Prettier and `git diff --check`
- Extension Development Host visual review of Light, Dark, custom gradients, and indicator updates after settings/theme changes