### PR TITLE
ci: improve extension release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'
@@ -33,12 +33,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'
@@ -55,12 +55,12 @@ jobs:
       - lint
       - test
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'
@@ -70,7 +70,7 @@ jobs:
     - run: pnpm dlx @vscode/vsce package --no-dependencies
 
     - name: Upload VSIX artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: svn-blamer-vsix-${{ github.sha }}
         path: "*.vsix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: 'package.json'
           cache: "pnpm"
@@ -76,7 +76,7 @@ jobs:
         run: echo "name=$(ls *.vsix)" >> $GITHUB_OUTPUT
 
       - name: Upload Extension Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.vsix_file.outputs.name }}
           path: ${{ steps.vsix_file.outputs.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
           - pre-release
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   run-release:
@@ -81,6 +81,12 @@ jobs:
           name: ${{ steps.vsix_file.outputs.name }}
           path: ${{ steps.vsix_file.outputs.name }}
           retention-days: 5
+
+      - name: Upload VSIX to GitHub release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.vsix_file.outputs.name }}
 
       - name: Publish to Open VSX Registry
         if: ${{ github.event_name == 'release' && steps.release_meta.outputs.type == 'stable' }}

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,6 +1,0 @@
-# Bolt's Journal
-
-## 2024-05-23 - Initial Setup
-
-**Learning:** The project is missing the `compile` script referenced in `pretest`.
-**Action:** Use `npm run compile-tests` and `npm run lint` for verification instead of `npm test` until the script is fixed (if I were allowed to fix it).


### PR DESCRIPTION
## Why this PR exists

SVN Blamer 1.1.0 built and published successfully, but its VSIX was available only as a five-day Actions artifact. Users who need a manual installation need a stable download on the GitHub release page.

There is no linked issue for this small release-maintenance change.

## What changed

- Upload the built VSIX to every published GitHub release, including pre-releases.
- Keep the existing short-lived Actions artifact for build inspection.
- Update checkout, pnpm setup, Node setup, and artifact upload actions to Node 24-based releases. The extension itself already uses Node 24.
- Remove the obsolete `.jules` note, which was otherwise included in the packaged extension.

## Notes for reviewers

- The existing publisher action remains in place. Its current release still embeds Node 20, so GitHub may continue to show its upstream deprecation warning even though the runner forces Node 24.
- This does not change extension functionality or the existing marketplace publishing flow.

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/release.yml`
- Hosted lint, test, and CodeQL checks are in progress.
